### PR TITLE
fix: Resolve Docker build failure in deployment environment

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,11 +1,11 @@
 # Multi-stage build for production frontend
-FROM node:18-alpine as builder
+FROM node:18-alpine AS builder
 
 # Set working directory
 WORKDIR /app
 
 # Copy package files  
-COPY package*.json ./
+COPY frontend/package*.json ./
 
 # Install all dependencies (including dev dependencies needed for build)
 RUN npm ci && npm cache clean --force
@@ -21,7 +21,7 @@ ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_WS_URL=$VITE_WS_URL
 
 # Copy source code
-COPY . .
+COPY frontend/ .
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
## Problem
Development deployment was failing at Docker build step with error:
```
npm error The `npm ci` command can only install with an existing package-lock.json or
npm error npm-shrinkwrap.json with lockfileVersion >= 1.
```

## Root Cause
The Docker build command uses repository root as build context (`.`) with Dockerfile at `frontend/Dockerfile.prod`, but the Dockerfile was trying to copy `package*.json` from root instead of `frontend/package*.json`.

**Build Command**: 
```bash
docker build -f frontend/Dockerfile.prod ... .
```

**Issue**: Build context is repository root, but COPY commands expected files in wrong location.

## Solution
- ✅ **Fixed COPY paths**: Updated `COPY package*.json ./` to `COPY frontend/package*.json ./`
- ✅ **Fixed source copy**: Updated `COPY . .` to `COPY frontend/ .`  
- ✅ **Fixed Docker warning**: Changed `FROM node:18-alpine as builder` to `FROM node:18-alpine AS builder`

## Verification
This fix ensures:
1. `package.json` and `package-lock.json` are correctly copied to Docker container
2. `npm ci` can run successfully with existing lockfile
3. Frontend builds properly in deployment environment
4. No Docker syntax warnings

## Test Plan
- [x] Verify files exist at expected paths in repository
- [ ] Test deployment build (will be validated by CI)
- [ ] Confirm development environment deploys successfully

This resolves the blocking deployment issue preventing Phase 2 frontend from being deployed.

🤖 Generated with [Claude Code](https://claude.ai/code)